### PR TITLE
Verify package runtime on Node 16

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  node16-runtime:
+    name: Node 16 package runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: node:16.20.2-bullseye@sha256:cd59a61258b82b86c1ff0ead50c8a689f6c3483c5ed21036e11ee741add419eb
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install frozen dependencies without lifecycle scripts
+        run: corepack yarn install --frozen-lockfile --ignore-scripts --ignore-engines
+      - name: Load CommonJS and ESM package entries
+        run: corepack yarn package:runtime
+
   node:
     name: Node ${{ matrix.node }} package verification
     runs-on: ubuntu-24.04

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-12
 
+- Added a digest-pinned Node 16.20.2 hosted smoke for the checked-in CommonJS
+  and ESM package entry points.
 - Added packed, unpacked, and per-file package size budgets to `pack:check`.
 - Rejected malformed npm size metadata and oversized expected package files
   with focused regression coverage.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ TypeScript declarations are included for both the default export and the named `
 
 The package exposes a root `exports` map with CommonJS and ESM entry points, and keeps `main`, `module`, and `types` fields for compatibility. Supported peer dependency majors are React 18 or 19 and styled-components 5 or 6.
 
-The published package supports Node 16 or newer for package resolution. Repository verification uses Node 20 or newer because the dev-only package validation tools require it.
+The published package supports Node 16 or newer for package resolution. A
+dedicated hosted Node 16.20.2 job loads both checked-in package entry modes;
+repository development verification uses Node 20 or newer because the dev-only
+package validation tools require it.
 
 ```js
 import React, { useState } from 'react'
@@ -319,8 +322,11 @@ TypeScript checks, Jest with coverage thresholds, a dependency audit, a strict p
 64 KiB compressed, 256 KiB unpacked, and 64 KiB per-file package size budget.
 `corepack yarn docs:smoke` builds the docs, serves them locally, captures desktop, mobile, and narrow-mobile
 screenshots with headless Chrome or Chromium, and checks the rendered DOM, screenshots, and horizontal layout metrics.
-GitHub Actions runs the frozen, lifecycle-script-free dependency graph and full verification on Node 20 and Node 24,
-then rebuilds `dist` and rejects generated output drift. Hosted actions are commit-pinned, use read-only permissions, disable checkout credential persistence, and run for every pushed branch, pull request, or manual dispatch.
+GitHub Actions runs a frozen, lifecycle-script-free Node 16 package runtime
+smoke plus the full verification graph on Node 20 and Node 24, then rebuilds
+`dist` and rejects generated output drift. Hosted actions are commit-pinned,
+use read-only permissions, disable checkout credential persistence, and run for
+every pushed branch, pull request, or manual dispatch.
 
 See `docs/plans/2026-06-08-react-booking-selector-baseline.md` for the current package verification baseline.
 See `docs/plans/2026-06-08-docs-plan-inventory-check.md` for the docs-plan inventory baseline.
@@ -339,3 +345,4 @@ See `docs/plans/2026-06-10-package-duplicate-file-check.md` for duplicate packag
 See `docs/plans/2026-06-10-package-file-mode-check.md` for packed-file executable mode rejection.
 See `docs/plans/2026-06-10-hosted-verification.md` for the pinned Node 20/24 verification and clean distribution gate.
 See `docs/plans/2026-06-12-package-size-budget.md` for fail-closed packed, unpacked, and per-file size ceilings.
+See `docs/plans/2026-06-12-node16-package-runtime.md` for the advertised runtime-floor package smoke.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,8 @@ Helpful reports include:
 - Interaction code should preserve safe browser behavior, including blocked-cell handling, keyboard access, touch event cleanup, and avoiding denial-of-service-prone input processing.
 - Dependency manifests detected: package.json, yarn.lock. Dependency updates should preserve lockfiles when present and avoid introducing packages without a clear maintenance reason.
 - Hosted verification installs the frozen lockfile with lifecycle scripts disabled, uses read-only repository permissions, disables checkout credential persistence, pins actions, runs the dependency audit, and rejects generated package drift.
+- The advertised Node 16 runtime floor separately loads both checked-in package
+  entry modes in a digest-pinned container without running install scripts.
 - Package verification enforces a reviewed package size budget alongside the
   exact allowlist and non-executable file modes so expected paths cannot hide
   accidental oversized release payloads.

--- a/docs/plans/2026-06-12-node16-package-runtime.md
+++ b/docs/plans/2026-06-12-node16-package-runtime.md
@@ -1,0 +1,52 @@
+# Node 16 Package Runtime Verification
+
+## Status: Completed
+
+## Context
+
+The published package declares `node >=16`, and package tooling verifies its
+exports and type declarations on current Node releases. Hosted execution runs
+the complete development gate on Node 20 and 24, but no job currently loads
+the checked-in CommonJS and ESM package entries on the advertised Node 16
+runtime floor.
+
+## Priority
+
+Package consumers execute the generated entry points rather than the source or
+development toolchain. A syntax or conditional-exports regression can pass the
+modern build matrix while breaking supported Node 16 applications.
+
+## Objectives
+
+- Add one dependency-light smoke command for the checked-in CommonJS and ESM
+  package entry points.
+- Run that command in a dedicated hosted Node 16 job.
+- Keep installs lockfile-frozen and lifecycle-script-free.
+- Keep the complete format, lint, type, test, audit, package, and reproducible
+  build gate on Node 20 and 24.
+- Protect the workflow, smoke command, tests, documentation, and completed plan
+  with repository contracts.
+
+## Work Completed
+
+- Added `package:runtime` to load the checked-in CommonJS and ESM package
+  entries and assert their public export shapes.
+- Added a focused Jest regression for the runtime smoke command.
+- Added a dedicated hosted Node 16.20.2 job using an immutable container digest,
+  frozen lockfile installation, and disabled lifecycle scripts.
+- Extended workflow and package-script contracts plus maintenance
+  documentation.
+
+## Verification
+
+- `corepack yarn jest test/scripts/smoke-package-runtime.test.js test/scripts/check-docs-plan.test.js test/lib/package-root.test.js --runInBand`
+- `corepack yarn package:runtime`
+- `corepack yarn verify`
+- `make check`
+- The exact Node 16.20.2 container digest executed
+  `node scripts/smoke-package-runtime.js` with networking disabled and loaded
+  both entry modes successfully. The hosted job runs the same command through
+  Yarn after its frozen online install.
+- Two focused hostile mutations removed the Node 16 job and the ESM entry-mode
+  probe; repository contracts rejected both.
+- Workflow YAML parse and `git diff --check`

--- a/package.json
+++ b/package.json
@@ -97,8 +97,9 @@
     "docs:deploy": "yarn docs:build && npx --yes surge@0.27.4 dist/docs --domain react-booking-selector.surge.sh",
     "docs:check": "node scripts/check-docs-plan.js",
     "pack:check": "node scripts/check-package-contents.js",
+    "package:runtime": "node scripts/smoke-package-runtime.js",
     "package:lint": "publint --pack npm --strict && attw --pack .",
-    "verify": "yarn docs:check && yarn format:check && yarn lint && yarn types:check && yarn cover:check && yarn audit --json && yarn pack:check && yarn package:lint",
+    "verify": "yarn docs:check && yarn format:check && yarn lint && yarn types:check && yarn cover:check && yarn audit --json && yarn pack:check && yarn package:runtime && yarn package:lint",
     "start": "yarn docs:dev"
   },
   "engines": {

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -100,8 +100,13 @@ if (planPaths.includes(ciPlanPath)) {
       'persist-credentials: false',
       'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
       'node: [20.x, 24.x]',
+      'name: Node 16 package runtime',
+      'timeout-minutes: 10',
+      'image: node:16.20.2-bullseye@sha256:cd59a61258b82b86c1ff0ead50c8a689f6c3483c5ed21036e11ee741add419eb',
       'run: corepack enable',
       'corepack yarn install --frozen-lockfile --ignore-scripts',
+      'corepack yarn install --frozen-lockfile --ignore-scripts --ignore-engines',
+      'run: corepack yarn package:runtime',
       'run: make check',
       'run: make build',
       'run: git diff --exit-code -- dist',
@@ -115,15 +120,16 @@ if (planPaths.includes(ciPlanPath)) {
       errors.push(`${ciWorkflowPath} must validate every pushed branch and pull request`)
     }
 
-    const uniqueFragments = [
-      'permissions:\n  contents: read',
-      'actions/checkout@',
-      'persist-credentials: false',
-      'actions/setup-node@',
-    ]
-    for (const fragment of uniqueFragments) {
-      if (countOccurrences(workflow, fragment) !== 1) {
-        errors.push(`${ciWorkflowPath} must include ${fragment} exactly once`)
+    const expectedOccurrences = new Map([
+      ['permissions:\n  contents: read', 1],
+      ['actions/checkout@', 2],
+      ['persist-credentials: false', 2],
+      ['actions/setup-node@', 1],
+      ['run: corepack yarn package:runtime', 1],
+    ])
+    for (const [fragment, expectedCount] of expectedOccurrences) {
+      if (countOccurrences(workflow, fragment) !== expectedCount) {
+        errors.push(`${ciWorkflowPath} must include ${fragment} exactly ${expectedCount} time(s)`)
       }
     }
 

--- a/scripts/smoke-package-runtime.js
+++ b/scripts/smoke-package-runtime.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { execFileSync } = require('node:child_process')
+
+const runNode = (args) =>
+  execFileSync(process.execPath, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+
+const commonJsResult = runNode([
+  '-e',
+  "const BookingSelector = require('react-booking-selector'); console.log(`${typeof BookingSelector}:${BookingSelector.default === BookingSelector}:${BookingSelector.BookingSelector === BookingSelector}:${BookingSelector.__esModule === true}`)",
+])
+
+if (commonJsResult !== 'function:true:true:true') {
+  throw new Error(`CommonJS package entry smoke failed: ${commonJsResult}`)
+}
+
+const esmResult = runNode([
+  '--input-type=module',
+  '-e',
+  "import BookingSelector, { BookingSelector as NamedBookingSelector } from 'react-booking-selector'; console.log(`${typeof BookingSelector}:${BookingSelector === NamedBookingSelector}`)",
+])
+
+if (esmResult !== 'function:true') {
+  throw new Error(`ESM package entry smoke failed: ${esmResult}`)
+}
+
+process.stdout.write(`Package runtime smoke passed on ${process.version}.\n`)

--- a/test/lib/package-root.test.js
+++ b/test/lib/package-root.test.js
@@ -23,6 +23,8 @@ it('exposes repository Makefile gate wrappers', () => {
   const makefile = readFileSync('Makefile', 'utf8')
 
   expect(packageJson.scripts.test).toBe('yarn lib:build && jest --runInBand')
+  expect(packageJson.scripts['package:runtime']).toBe('node scripts/smoke-package-runtime.js')
+  expect(packageJson.scripts.verify).toContain('yarn package:runtime')
   expect(makefile).toMatch(/^\.DEFAULT_GOAL := check$/m)
   expect(makefile).toMatch(/^check: verify$/m)
   expect(makefile).toMatch(/^lint:\n\tcorepack yarn lint$/m)
@@ -89,4 +91,15 @@ it('supports the package ESM import condition', () => {
   )
 
   expect(output.trim()).toBe('function:true')
+})
+
+it('keeps the runtime-floor smoke fail-closed for both package entry modes', () => {
+  const runtimeSmoke = readFileSync('scripts/smoke-package-runtime.js', 'utf8')
+
+  expect(runtimeSmoke).toContain("require('react-booking-selector')")
+  expect(runtimeSmoke).toContain(
+    "import BookingSelector, { BookingSelector as NamedBookingSelector } from 'react-booking-selector'",
+  )
+  expect(runtimeSmoke).toContain("commonJsResult !== 'function:true:true:true'")
+  expect(runtimeSmoke).toContain("esmResult !== 'function:true'")
 })

--- a/test/scripts/check-docs-plan.test.js
+++ b/test/scripts/check-docs-plan.test.js
@@ -21,6 +21,19 @@ permissions:
   contents: read
 
 jobs:
+  node16-runtime:
+    name: Node 16 package runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: node:16.20.2-bullseye@sha256:cd59a61258b82b86c1ff0ead50c8a689f6c3483c5ed21036e11ee741add419eb
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - run: corepack enable
+      - run: corepack yarn install --frozen-lockfile --ignore-scripts --ignore-engines
+      - run: corepack yarn package:runtime
   node:
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/test/scripts/smoke-package-runtime.test.js
+++ b/test/scripts/smoke-package-runtime.test.js
@@ -1,0 +1,11 @@
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+it('loads both package entry modes in the active Node runtime', () => {
+  const output = execFileSync(process.execPath, [path.join(process.cwd(), 'scripts/smoke-package-runtime.js')], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  })
+
+  expect(output).toBe(`Package runtime smoke passed on ${process.version}.\n`)
+})


### PR DESCRIPTION
## Summary

Verify the advertised Node 16 package runtime floor without weakening the existing Node 20 and Node 24 development, packaging, and reproducibility gates.

## Baseline

The package advertised Node 16 compatibility, but its hosted workflow did not execute the checked-in CommonJS and ESM entry conditions under that runtime. The modern Node 20/24 development gates already covered the broader build and verification suite.

## Improvements

- add a dedicated digest-pinned Node 16.20.2 hosted runtime job for the advertised package floor
- load both checked-in CommonJS and ESM entry conditions and assert their public export shapes
- keep installation frozen and lifecycle-script-free while leaving the full Node 20/24 development gate unchanged
- add fail-closed workflow, package-script, test, plan, and documentation contracts

## Validation

- `make check`: 378 tests, 100% covered production/checker code, zero audit vulnerabilities
- exact `node:16.20.2-bullseye@sha256:cd59...419eb` container executed the runtime smoke with networking disabled
- `publint --pack npm --strict` and `attw --pack .`
- package contents and size checks passed for 27 files
- workflow YAML parse and `git diff --check`
- hostile removal of the Node 16 job and ESM probe was rejected
- all six hosted checks succeeded at `62440a110f45cd597e1c09fc8bf8c38406fc55c3`: two Node 16 runtime checks and two each for Node 20 and Node 24 package verification

## Risk

No remaining actionable findings were identified. Checked-in `dist` is unchanged, and the modern Node 20/24 build and reproducibility jobs remain intact. The new job verifies the published entry surfaces rather than rebuilding them under the legacy runtime.

## Follow-Ups

- Keep the Node 16 runtime smoke aligned with the advertised package floor until support is intentionally raised and documented.
