### PR TITLE
build: make package gates location independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,18 @@
 
 .PHONY: build check lint test verify
 
+override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 check: verify
 
 lint:
-	corepack yarn lint
+	cd "$(REPO_ROOT)" && corepack yarn lint
 
 test:
-	corepack yarn test
+	cd "$(REPO_ROOT)" && corepack yarn test
 
 build:
-	corepack yarn build
+	cd "$(REPO_ROOT)" && corepack yarn build
 
 verify:
-	corepack yarn verify
+	cd "$(REPO_ROOT)" && corepack yarn verify

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ See `docs/plans/2026-06-08-custom-render-state-coverage.md` for custom cell rend
 See `docs/plans/2026-06-08-custom-render-keyboard-coverage.md` for keyboard coverage around custom-rendered cells.
 
 See `docs/plans/2026-06-13-home-end-keyboard-navigation.md` for row-edge and whole-grid keyboard navigation coverage.
+See `docs/plans/2026-06-14-location-independent-make.md` for location-independent Make gate coverage.
 See `docs/plans/2026-06-09-minute-unique-selection.md` for minute-unique selection payload handling.
 See `docs/plans/2026-06-09-docs-plan-readme-references.md` for README plan-link coverage.
 See `docs/plans/2026-06-09-docs-plan-readme-unique-references.md` for unique README plan-link coverage.

--- a/docs/plans/2026-06-14-location-independent-make.md
+++ b/docs/plans/2026-06-14-location-independent-make.md
@@ -1,6 +1,6 @@
 # Location-Independent Make Gates
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -31,9 +31,25 @@ therefore resolves the wrong package and cannot reproduce the package gate.
   and generated-artifact scans
 - `git diff --check`
 
-## Work Planned
+## Work Completed
 
-- Add an override-protected absolute repository root to the Makefile.
-- Root lint, test, build, and verify recipes.
-- Extend the docs-plan checker with exact Make and completed-plan evidence
+- Added an override-protected absolute repository root to the Makefile.
+- Rooted lint, test, build, and verify recipes.
+- Extended the docs-plan checker with exact Make and completed-plan evidence
   contracts.
+
+## Verification Results
+
+- Node 20.19.5 and Node 24.16.0 passed full `corepack yarn verify` and
+  `make check` runs from both the repository root and an unrelated directory
+  with `REPO_ROOT=/tmp` supplied on the command line.
+- Each full run passed 387 tests, two snapshots, coverage thresholds, audit,
+  package contents and size checks, Node 16 runtime smoke, and package lint.
+- Five hostile mutations rejected removal of override protection and every
+  rooted executable recipe.
+- Exact-base checks preserved source, package metadata, lockfile, workflow, and
+  generated distribution output; no generated or untracked artifacts remained.
+- `git diff --check` and secret, captured-prompt, dependency, workflow, and
+  generated-artifact scans passed.
+- Node 24 emitted the existing dependency-level `url.parse()` deprecation
+  warning; the full supported gate still passed without suppressing it.

--- a/docs/plans/2026-06-14-location-independent-make.md
+++ b/docs/plans/2026-06-14-location-independent-make.md
@@ -1,0 +1,39 @@
+# Location-Independent Make Gates
+
+## Status: Planned
+
+## Context
+
+The Make recipes invoke Corepack and Yarn in the caller's current directory.
+Using the repository Makefile through an absolute path from another directory
+therefore resolves the wrong package and cannot reproduce the package gate.
+
+## Objectives
+
+- Resolve the repository root from the loaded Makefile.
+- Run every executable Make recipe from that root, independent of the caller.
+- Protect the root derivation and rooted recipes with mutation-sensitive docs
+  contracts.
+- Preserve the existing lint, test, build, and full verification behavior.
+
+## Scope Boundaries
+
+- Do not change component behavior, package APIs, dependencies, generated
+  distribution contents, or hosted workflow coverage.
+- Do not run deployment or publishing commands.
+
+## Verification
+
+- every Make alias from the repository root and an unrelated directory
+- full `corepack yarn verify` and `make check` on Node 20 and Node 24
+- hostile mutations covering root derivation and every rooted recipe
+- package manifest, distribution, dependency, workflow, secret, captured-prompt,
+  and generated-artifact scans
+- `git diff --check`
+
+## Work Planned
+
+- Add an override-protected absolute repository root to the Makefile.
+- Root lint, test, build, and verify recipes.
+- Extend the docs-plan checker with exact Make and completed-plan evidence
+  contracts.

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -10,6 +10,7 @@ const toFsPath = (planPath) => path.join(...planPath.split('/'))
 const baselinePlanPath = toPlanPath('2026-06-08-react-booking-selector-baseline.md')
 const ciPlanPath = toPlanPath('2026-06-10-hosted-verification.md')
 const homeEndPlanPath = toPlanPath('2026-06-13-home-end-keyboard-navigation.md')
+const locationIndependentMakePlanPath = toPlanPath('2026-06-14-location-independent-make.md')
 const ciWorkflowPath = '.github/workflows/check.yml'
 const workflowDir = '.github/workflows'
 const codeownersPath = '.github/CODEOWNERS'
@@ -212,8 +213,29 @@ for (const [readmePlanReference, referenceCount] of readmePlanReferenceCounts) {
   }
 }
 
+const makeContracts = [
+  'override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))',
+  'lint:\n\tcd "$(REPO_ROOT)" && corepack yarn lint',
+  'test:\n\tcd "$(REPO_ROOT)" && corepack yarn test',
+  'build:\n\tcd "$(REPO_ROOT)" && corepack yarn build',
+  'verify:\n\tcd "$(REPO_ROOT)" && corepack yarn verify',
+]
 if (!makefile.includes('corepack yarn verify')) {
   errors.push('Makefile must expose corepack yarn verify')
+}
+for (const makeContract of makeContracts) {
+  if (!makefile.includes(makeContract)) {
+    errors.push(`Makefile must preserve rooted contract: ${makeContract}`)
+  }
+}
+
+if (planPaths.includes(locationIndependentMakePlanPath)) {
+  const locationIndependentMakePlan = fs.readFileSync(toFsPath(locationIndependentMakePlanPath), 'utf8')
+  for (const evidence of ['Node 20', 'Node 24', 'unrelated directory', 'hostile mutations rejected']) {
+    if (!locationIndependentMakePlan.includes(evidence)) {
+      errors.push(`${locationIndependentMakePlanPath} must preserve completed evidence: ${evidence}`)
+    }
+  }
 }
 
 if (errors.length > 0) {

--- a/test/lib/package-root.test.js
+++ b/test/lib/package-root.test.js
@@ -26,11 +26,12 @@ it('exposes repository Makefile gate wrappers', () => {
   expect(packageJson.scripts['package:runtime']).toBe('node scripts/smoke-package-runtime.js')
   expect(packageJson.scripts.verify).toContain('yarn package:runtime')
   expect(makefile).toMatch(/^\.DEFAULT_GOAL := check$/m)
+  expect(makefile).toMatch(/^override REPO_ROOT := \$\(abspath \$\(dir \$\(lastword \$\(MAKEFILE_LIST\)\)\)\)$/m)
   expect(makefile).toMatch(/^check: verify$/m)
-  expect(makefile).toMatch(/^lint:\n\tcorepack yarn lint$/m)
-  expect(makefile).toMatch(/^test:\n\tcorepack yarn test$/m)
-  expect(makefile).toMatch(/^build:\n\tcorepack yarn build$/m)
-  expect(makefile).toMatch(/^verify:\n\tcorepack yarn verify$/m)
+  expect(makefile).toMatch(/^lint:\n\tcd "\$\(REPO_ROOT\)" && corepack yarn lint$/m)
+  expect(makefile).toMatch(/^test:\n\tcd "\$\(REPO_ROOT\)" && corepack yarn test$/m)
+  expect(makefile).toMatch(/^build:\n\tcd "\$\(REPO_ROOT\)" && corepack yarn build$/m)
+  expect(makefile).toMatch(/^verify:\n\tcd "\$\(REPO_ROOT\)" && corepack yarn verify$/m)
 })
 
 it('keeps local editor metadata out of verification inputs', () => {

--- a/test/scripts/check-docs-plan.test.js
+++ b/test/scripts/check-docs-plan.test.js
@@ -65,6 +65,27 @@ const completedPlan = (title) => `# ${title}
 - make check
 `
 
+const rootedMakefile = `.DEFAULT_GOAL := check
+
+.PHONY: build check lint test verify
+
+override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+check: verify
+
+lint:
+	cd "$(REPO_ROOT)" && corepack yarn lint
+
+test:
+	cd "$(REPO_ROOT)" && corepack yarn test
+
+build:
+	cd "$(REPO_ROOT)" && corepack yarn build
+
+verify:
+	cd "$(REPO_ROOT)" && corepack yarn verify
+`
+
 const createTempProject = ({ withHostedVerification = true } = {}) => {
   const projectPath = mkdtempSync(path.join(tmpdir(), 'react-booking-selector-docs-check-'))
   mkdirSync(path.join(projectPath, ...planDir.split('/')), { recursive: true })
@@ -155,7 +176,7 @@ describe('check-docs-plan script', () => {
     writePlan(projectPath, extraPlanPath, completedPlan('Extra Plan'))
     writePlan(projectPath, leapDayPlanPath, completedPlan('Leap Day Plan'))
     writeReadme(projectPath, [baselinePlanPath, extraPlanPath, leapDayPlanPath])
-    writeFileSync(path.join(projectPath, 'Makefile'), 'verify:\n\tcorepack yarn verify\n')
+    writeFileSync(path.join(projectPath, 'Makefile'), rootedMakefile)
 
     expect(runDocsCheck(projectPath)).toBe('Docs plan check passed for 4 plan(s).\n')
   })
@@ -166,7 +187,7 @@ describe('check-docs-plan script', () => {
     writePlan(projectPath, baselinePlanPath, completedPlan('Baseline Plan'))
     writeHostedVerification(projectPath)
     writeReadme(projectPath, [baselinePlanPath, ciPlanPath])
-    writeFileSync(path.join(projectPath, 'Makefile'), 'verify:\n\tcorepack yarn verify\n')
+    writeFileSync(path.join(projectPath, 'Makefile'), rootedMakefile)
 
     expect(runDocsCheck(projectPath)).toBe('Docs plan check passed for 2 plan(s).\n')
   })
@@ -187,7 +208,7 @@ describe('check-docs-plan script', () => {
     )
     writeFileSync(path.join(projectPath, '.github', 'workflows', 'extra.yml'), 'name: Extra\n')
     writeReadme(projectPath, [baselinePlanPath, ciPlanPath])
-    writeFileSync(path.join(projectPath, 'Makefile'), 'verify:\n\tcorepack yarn verify\n')
+    writeFileSync(path.join(projectPath, 'Makefile'), rootedMakefile)
 
     const stderr = runDocsCheckFailure(projectPath)
 
@@ -205,7 +226,7 @@ describe('check-docs-plan script', () => {
     tempProjects.push(projectPath)
     writePlan(projectPath, baselinePlanPath, completedPlan('Baseline Plan'))
     writeReadme(projectPath, [baselinePlanPath])
-    writeFileSync(path.join(projectPath, 'Makefile'), 'verify:\n\tcorepack yarn verify\n')
+    writeFileSync(path.join(projectPath, 'Makefile'), rootedMakefile)
     const preloadPath = writeWin32PathPreload(projectPath)
 
     expect(runDocsCheck(projectPath, ['--require', preloadPath])).toBe('Docs plan check passed for 2 plan(s).\n')


### PR DESCRIPTION
## Summary

Package verification now runs against the repository selected by the Makefile, even when invoked from another directory. A command-line `REPO_ROOT` override cannot redirect lint, tests, builds, or the full package gate.

## Baseline

The Make recipes previously ran Corepack and Yarn in the caller's directory. Absolute-path Makefile invocations could therefore resolve a different package or fail before exercising this repository's checks.

## Improvements

- Derive an override-protected repository root from the loaded Makefile.
- Run lint, test, build, and verify from that root.
- Extend docs-plan and package-root tests so all rooted recipes and completed evidence remain mutation-sensitive.

## Validation

- Node 20.19.5 and Node 24.16.0 full `make check` from the checkout and `/tmp` with hostile `REPO_ROOT=/tmp`
- 387 tests and two snapshots in each full run
- coverage, audit, package contents and size, Node 16 runtime smoke, and package lint
- five hostile Make mutations rejected
- exact-base source, package, lockfile, workflow, and `dist` preservation
- formatting, diff, secret, prompt, dependency, workflow, and artifact scans

## Risk

- This PR is stacked on the Home/End navigation branch and must not be merged independently.
- Node 24 emits an existing dependency-level `url.parse()` deprecation warning; the full supported gate passes without suppressing it.

## Follow-Ups

- Keep the pull request open for owner review and merge it only after the stacked base is accepted.
- Address the Node 24 deprecation in a separate dependency-focused change with package-output verification.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)
