### PR TITLE
Separate package publishing from docs deployment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   digest-pinned Node 16.20.2 container.
 - Added fail-closed contracts for the package manager, linker, audit command,
   hosted install mode, and artifact-based runtime boundary.
+- Removed automatic documentation deployment from the package publish lifecycle
+  while preserving the explicit pinned deployment command.
 
 ## 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ packs on Node 20, then loads the read-only artifact under digest-pinned Node
 generated output drift. Actions are commit-pinned, use read-only permissions,
 disable checkout credential persistence, and run for every pushed branch, pull
 request, or manual dispatch.
+Package publication and documentation deployment are separate maintainer
+actions: publishing never runs a deploy lifecycle hook, and documentation is
+deployed only through an explicit `corepack yarn docs:deploy` invocation.
 
 See `docs/plans/2026-06-08-react-booking-selector-baseline.md` for the current package verification baseline.
 See `docs/plans/2026-06-08-docs-plan-inventory-check.md` for the docs-plan inventory baseline.
@@ -339,6 +342,7 @@ See `docs/plans/2026-06-08-custom-render-keyboard-coverage.md` for keyboard cove
 See `docs/plans/2026-06-13-home-end-keyboard-navigation.md` for row-edge and whole-grid keyboard navigation coverage.
 See `docs/plans/2026-06-14-location-independent-make.md` for location-independent Make gate coverage.
 See `docs/plans/2026-06-15-yarn-4-package-manager.md` for the Yarn 4 toolchain and Node 16 artifact boundary.
+See `docs/plans/2026-06-15-explicit-docs-deployment.md` for package publication and documentation deployment separation.
 See `docs/plans/2026-06-09-minute-unique-selection.md` for minute-unique selection payload handling.
 See `docs/plans/2026-06-09-docs-plan-readme-references.md` for README plan-link coverage.
 See `docs/plans/2026-06-09-docs-plan-readme-unique-references.md` for unique README plan-link coverage.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,9 @@ Helpful reports include:
 - Package verification enforces a reviewed package size budget alongside the
   exact allowlist and non-executable file modes so expected paths cannot hide
   accidental oversized release payloads.
+- Package publication has no deployment lifecycle hook. Documentation
+  deployment requires the separate explicit `corepack yarn docs:deploy`
+  maintainer action, keeping registry and deployment privileges independent.
 
 ## Service and API Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -37,6 +37,7 @@ Priority:
 - Reject duplicate package file entries in manifest and dry-run package checks
 - Reject executable file modes from the published package surface
 - Enforce packed, unpacked, and per-file package size budgets
+- Keep package publication separate from explicit documentation deployment
 - Keep canonical maintenance plan filenames dated and sortable
 - Keep date, selection, touch, and docs-smoke helpers defensive against
   malformed or invalid inputs

--- a/docs/plans/2026-06-15-explicit-docs-deployment.md
+++ b/docs/plans/2026-06-15-explicit-docs-deployment.md
@@ -1,0 +1,89 @@
+# Require Explicit Documentation Deployment
+
+## Status: Planned
+
+## Context
+
+`package.json` currently maps `postpublish` to `corepack yarn docs:deploy`.
+Package-manager lifecycle semantics therefore couple every package publication
+to a second external action that builds documentation, downloads and executes
+Surge through `npx --yes`, and attempts a production documentation deployment.
+The package may already be published when that unrelated deployment fails.
+
+Documentation deployment should remain available as an explicit maintainer
+command, but publishing the package must not trigger it automatically.
+
+## Priority
+
+High release safety. Separate registry publication from external deployment so
+each privileged action is intentional, independently observable, and can fail
+without misrepresenting the state of the other.
+
+## Requirements
+
+- R1. Remove the `postpublish` lifecycle hook from `package.json`.
+- R2. Preserve the explicit `docs:deploy` command and its pinned Surge version.
+- R3. Preserve `prepack`, package builds, package contents, and all runtime and
+  accessibility behavior.
+- R4. Add fail-closed tests and repository checks that reject any automatic
+  `prepublish`, `publish`, or `postpublish` documentation deployment hook.
+- R5. Document that package publication and documentation deployment are
+  separate explicit maintainer actions.
+- R6. Record completed package, mutation, audit, and hosted verification
+  evidence without publishing or deploying anything.
+
+## Scope Boundaries
+
+- Do not run `npm publish`, `yarn npm publish`, Surge, or any deployment command.
+- Do not change package versions, package contents, dependencies, lockfiles,
+  workflow permissions, deployment domains, or credentials.
+- Do not remove the explicit `docs:deploy` command.
+
+## Implementation Units
+
+### U1. Remove the automatic release hook
+
+- **Files:** `package.json`
+- Delete only `scripts.postpublish`; retain `prepack` and `docs:deploy` exactly.
+
+### U2. Protect release-script separation
+
+- **Files:** `test/lib/package-root.test.js`,
+  `scripts/check-docs-plan.js`
+- Require `postpublish`, `publish`, and `prepublish` to be absent.
+- Require the explicit `docs:deploy` command to retain the pinned Surge package
+  and reviewed domain.
+- Ensure mutations that restore an automatic hook or weaken the explicit
+  command are rejected.
+
+### U3. Document and verify the release boundary
+
+- **Files:** canonical maintenance documentation and this plan.
+- Explain that package publication does not deploy documentation and that
+  maintainers must invoke `corepack yarn docs:deploy` separately.
+- Run package, content, type, runtime, audit, documentation, and mutation gates
+  without contacting the registry or deployment service.
+
+## Verification Plan
+
+- Run focused package-root and docs-plan tests.
+- Run the full immutable Yarn 4 package gate from the repository and an
+  unrelated caller directory on Node 20.
+- Run the complete gate on Node 24 and the packed artifact runtime on the
+  digest-pinned, network-disabled Node 16 container.
+- Run isolated mutations for automatic lifecycle hooks, explicit deployment
+  preservation, documentation, and completed plan evidence.
+- Audit the exact diff, generated artifacts, credential patterns, package and
+  lockfile drift, workflow changes, and `git diff --check` before commit.
+
+## References
+
+- npm lifecycle scripts: https://docs.npmjs.com/cli/using-npm/scripts/
+- npm package scripts field: https://docs.npmjs.com/files/package.json/
+- npm `npx` command behavior: https://docs.npmjs.com/cli/commands/npx/
+
+## Risks
+
+- Maintainers accustomed to automatic docs deployment must run the explicit
+  command after publication when a documentation release is desired. Canonical
+  documentation will record this deliberate two-step release sequence.

--- a/docs/plans/2026-06-15-explicit-docs-deployment.md
+++ b/docs/plans/2026-06-15-explicit-docs-deployment.md
@@ -1,6 +1,6 @@
 # Require Explicit Documentation Deployment
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -64,17 +64,22 @@ without misrepresenting the state of the other.
 - Run package, content, type, runtime, audit, documentation, and mutation gates
   without contacting the registry or deployment service.
 
-## Verification Plan
+## Completion Evidence
 
-- Run focused package-root and docs-plan tests.
-- Run the full immutable Yarn 4 package gate from the repository and an
-  unrelated caller directory on Node 20.
-- Run the complete gate on Node 24 and the packed artifact runtime on the
-  digest-pinned, network-disabled Node 16 container.
-- Run isolated mutations for automatic lifecycle hooks, explicit deployment
-  preservation, documentation, and completed plan evidence.
-- Audit the exact diff, generated artifacts, credential patterns, package and
-  lockfile drift, workflow changes, and `git diff --check` before commit.
+- The focused package-root and docs-plan tests passed with 28 assertions.
+- `corepack yarn verify` and `make check` passed on Node 20.19.5 from the
+  repository and through the absolute Makefile path from an unrelated caller
+  directory.
+- The complete immutable package gate passed on Node 24.16.0 with
+  `NODE_OPTIONS=--trace-deprecation` and no deprecation output.
+- The package tarball built on Node 20 loaded both CommonJS and ESM entries on
+  the digest-pinned, network-disabled Node 16 runtime without package lifecycle
+  scripts.
+- Twelve isolated hostile mutations were rejected across automatic publish
+  hooks, prepack preservation, pinned explicit deployment, regression tests,
+  static checks, documentation, plan linking, and completed evidence.
+- Final generated-artifact, credential-pattern, package, lockfile, workflow,
+  and `git diff --check` audits passed without publishing or deploying.
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "license": "MIT",
   "scripts": {
     "prepack": "corepack yarn build",
-    "postpublish": "corepack yarn docs:deploy",
     "clean": "rm -rf dist/lib dist/esm dist/docs dev/docs .cache .parcel-cache coverage react-booking-selector-*.tgz",
     "clean:docs": "rm -rf dist/docs",
     "clean:lib": "rm -rf dist/lib dist/esm",

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -12,10 +12,12 @@ const ciPlanPath = toPlanPath('2026-06-10-hosted-verification.md')
 const homeEndPlanPath = toPlanPath('2026-06-13-home-end-keyboard-navigation.md')
 const locationIndependentMakePlanPath = toPlanPath('2026-06-14-location-independent-make.md')
 const yarnPackageManagerPlanPath = toPlanPath('2026-06-15-yarn-4-package-manager.md')
+const explicitDocsDeploymentPlanPath = toPlanPath('2026-06-15-explicit-docs-deployment.md')
 const ciWorkflowPath = '.github/workflows/check.yml'
 const workflowDir = '.github/workflows'
 const codeownersPath = '.github/CODEOWNERS'
 const packageJsonPath = 'package.json'
+const packageRootTestPath = 'test/lib/package-root.test.js'
 const yarnConfigPath = '.yarnrc.yml'
 const planDirFsPath = toFsPath(planDir)
 const makefile = fs.existsSync('Makefile') ? fs.readFileSync('Makefile', 'utf8') : ''
@@ -276,6 +278,75 @@ if (planPaths.includes(yarnPackageManagerPlanPath)) {
   for (const evidence of ['Node 20', 'Node 24', 'Node 16', 'hostile mutations rejected']) {
     if (!yarnPackageManagerPlan.includes(evidence)) {
       errors.push(`${yarnPackageManagerPlanPath} must preserve completed evidence: ${evidence}`)
+    }
+  }
+}
+
+if (planPaths.includes(explicitDocsDeploymentPlanPath)) {
+  if (!fs.existsSync(toFsPath(packageJsonPath))) {
+    errors.push(`${packageJsonPath} is required by ${explicitDocsDeploymentPlanPath}`)
+  } else {
+    const packageJson = JSON.parse(fs.readFileSync(toFsPath(packageJsonPath), 'utf8'))
+    for (const lifecycleHook of ['prepublish', 'publish', 'postpublish']) {
+      if (Object.hasOwn(packageJson.scripts ?? {}, lifecycleHook)) {
+        errors.push(`${packageJsonPath} must not define automatic ${lifecycleHook} deployment behavior`)
+      }
+    }
+    if (packageJson.scripts?.prepack !== 'corepack yarn build') {
+      errors.push(`${packageJsonPath} must preserve the reviewed prepack build`)
+    }
+    if (
+      packageJson.scripts?.['docs:deploy'] !==
+      'yarn docs:build && npx --yes surge@0.27.4 dist/docs --domain react-booking-selector.surge.sh'
+    ) {
+      errors.push(`${packageJsonPath} must preserve the explicit pinned documentation deployment command`)
+    }
+  }
+
+  if (!fs.existsSync(toFsPath(packageRootTestPath))) {
+    errors.push(`${packageRootTestPath} is required by ${explicitDocsDeploymentPlanPath}`)
+  } else {
+    const packageRootTest = fs.readFileSync(toFsPath(packageRootTestPath), 'utf8')
+    for (const testContract of [
+      "it('keeps documentation deployment explicit and separate from publishing'",
+      'expect(packageJson.scripts.prepublish).toBeUndefined()',
+      'expect(packageJson.scripts.publish).toBeUndefined()',
+      'expect(packageJson.scripts.postpublish).toBeUndefined()',
+      "expect(packageJson.scripts.prepack).toBe('corepack yarn build')",
+      "expect(packageJson.scripts['docs:deploy']).toBe(",
+      'npx --yes surge@0.27.4 dist/docs --domain react-booking-selector.surge.sh',
+    ]) {
+      if (!packageRootTest.includes(testContract)) {
+        errors.push(`${packageRootTestPath} must preserve release separation contract: ${testContract}`)
+      }
+    }
+  }
+
+  for (const [documentPath, fragment] of [
+    ['README.md', 'Package publication and documentation deployment are separate maintainer'],
+    ['SECURITY.md', 'Package publication has no deployment lifecycle hook.'],
+    ['VISION.md', 'Keep package publication separate from explicit documentation deployment'],
+    ['CHANGES.md', 'Removed automatic documentation deployment from the package publish lifecycle'],
+  ]) {
+    if (!fs.existsSync(toFsPath(documentPath))) {
+      errors.push(`${documentPath} is required by ${explicitDocsDeploymentPlanPath}`)
+    } else if (!fs.readFileSync(toFsPath(documentPath), 'utf8').includes(fragment)) {
+      errors.push(`${documentPath} must document explicit release and deployment separation`)
+    }
+  }
+
+  const explicitDocsDeploymentPlan = fs.readFileSync(toFsPath(explicitDocsDeploymentPlanPath), 'utf8')
+  for (const evidence of [
+    '## Status: Completed',
+    'focused package-root and docs-plan tests passed',
+    'Node 20',
+    'Node 24',
+    'Node 16',
+    'hostile mutations were rejected',
+    '`git diff --check`',
+  ]) {
+    if (!explicitDocsDeploymentPlan.includes(evidence)) {
+      errors.push(`${explicitDocsDeploymentPlanPath} must preserve completed evidence: ${evidence}`)
     }
   }
 }

--- a/test/lib/package-root.test.js
+++ b/test/lib/package-root.test.js
@@ -21,6 +21,16 @@ it('marks the published package as side-effect free', () => {
   expect(packageJson.sideEffects).toBe(false)
 })
 
+it('keeps documentation deployment explicit and separate from publishing', () => {
+  expect(packageJson.scripts.prepublish).toBeUndefined()
+  expect(packageJson.scripts.publish).toBeUndefined()
+  expect(packageJson.scripts.postpublish).toBeUndefined()
+  expect(packageJson.scripts.prepack).toBe('corepack yarn build')
+  expect(packageJson.scripts['docs:deploy']).toBe(
+    'yarn docs:build && npx --yes surge@0.27.4 dist/docs --domain react-booking-selector.surge.sh',
+  )
+})
+
 it('exposes repository Makefile gate wrappers', () => {
   const makefile = readFileSync('Makefile', 'utf8')
 


### PR DESCRIPTION
![Engineering bar](https://img.shields.io/badge/engineering--bar-validated-brightgreen)

## Summary

- Removes the automatic postpublish documentation deployment hook.
- Keeps the pinned documentation deployment available only as an explicit maintainer command.
- Adds fail-closed package, repository, documentation, and mutation contracts.

## Baseline

Package publication previously invoked the external Surge documentation deployment through the postpublish lifecycle.

## Improvements

- Registry publication and documentation deployment now fail independently.
- prepublish, publish, and postpublish hooks are prohibited by tests and the docs-plan checker.
- The reviewed prepack build and exact pinned docs:deploy command remain protected.

## Validation

- Node 20.19.5 full gate from the repository and an unrelated directory: 391 tests, 100% measured coverage, package, audit, types, lint, and formatting checks.
- Node 24.16.0 full gate with NODE_OPTIONS=--trace-deprecation.
- Digest-pinned, network-disabled Node 16.20.2 packed-artifact CommonJS and ESM smoke.
- 12 hostile lifecycle, command, test, checker, documentation, and evidence mutations rejected.
- Exact diff, generated-artifact, lockfile, workflow, credential-pattern, and whitespace audits passed.

## Risk

Maintainers must invoke corepack yarn docs:deploy explicitly after publication when a documentation release is desired.

## Follow-Ups

None required for this change.

## Post-Deploy Monitoring

Confirm the next package publication completes without a documentation deployment attempt; run and observe docs:deploy separately when documentation should be released.