### PR TITLE
fix: patch transitive yaml parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-20
+
+- Pinned `js-yaml` to 4.2.0 across legacy coverage tooling, removing the
+  transitive GHSA-h67p-54hq-rp68 finding that Dependabot could not update.
+- Added package and documentation-contract coverage for the patched parser
+  resolution.
+
 ## 2026-06-19
 
 - Retained document mouseup targets whose listener cleanup fails, retried every

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ See `docs/plans/2026-06-15-yarn-4-package-manager.md` for the Yarn 4 toolchain a
 See `docs/plans/2026-06-15-explicit-docs-deployment.md` for package publication and documentation deployment separation.
 See `docs/plans/2026-06-16-document-mouseup-listener-migration.md` for owner-document listener migration and retained-target cleanup.
 See `docs/plans/2026-06-19-listener-and-roving-focus-review.md` for failed-cleanup ownership and roving-focus review coverage.
+See `docs/plans/2026-06-20-js-yaml-security-resolution.md` for the patched transitive YAML parser boundary.
 See `docs/plans/2026-06-09-minute-unique-selection.md` for minute-unique selection payload handling.
 See `docs/plans/2026-06-09-docs-plan-readme-references.md` for README plan-link coverage.
 See `docs/plans/2026-06-09-docs-plan-readme-unique-references.md` for unique README plan-link coverage.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,8 @@ Helpful reports include:
   roving tab stop with focus as blocked and rendered boundaries change.
 - Dependency manifests detected: package.json, yarn.lock. Dependency updates should preserve lockfiles when present and avoid introducing packages without a clear maintenance reason.
 - Hosted verification uses immutable Yarn 4 installs with lifecycle scripts disabled, read-only repository permissions, disabled checkout credential persistence, pinned actions, a recursive dependency audit, and generated-package drift rejection.
+- The dependency graph pins `js-yaml 4.2.0` across legacy coverage tooling so
+  GHSA-h67p-54hq-rp68 cannot remain hidden behind a transitive 3.x range.
 - The advertised Node 16 runtime floor separately loads both package entry modes
   from a tarball built on Node 20 in a digest-pinned, network-disabled container
   without invoking Yarn 4 or package lifecycle scripts there.

--- a/docs/plans/2026-06-20-js-yaml-security-resolution.md
+++ b/docs/plans/2026-06-20-js-yaml-security-resolution.md
@@ -1,0 +1,31 @@
+# js-yaml Security Resolution
+
+## Status: Completed
+
+## Context
+
+Dependabot reported that `@istanbuljs/load-nyc-config` retained
+`js-yaml 3.14.2`, affected by GHSA-h67p-54hq-rp68, while the earliest patched
+release is `js-yaml 4.2.0`. The repository already used js-yaml 4 through its
+current ESLint graph, so a root Yarn resolution could consolidate the parser
+without changing the published component API.
+
+## Work Completed
+
+- Added an exact `js-yaml 4.2.0` root resolution.
+- Regenerated the Yarn 4 immutable lock so every js-yaml path uses the patched
+  release.
+- Added package and documentation checks that reject removal or weakening of
+  the security resolution.
+- Documented the dependency boundary in `SECURITY.md` and `CHANGES.md`.
+
+## Verification Completed
+
+- `corepack yarn install --immutable` reproduced the reviewed lockfile.
+- `corepack yarn verify` passed the complete package verification graph.
+- `corepack yarn why js-yaml` showed only `js-yaml 4.2.0`.
+- `make check` passed on Node 20 and Node 24.
+- An external-directory `make check` passed on Node 24.
+- Formatting, lint, types, 400 tests, coverage, hostile mutations, package
+  contents, Node 16 runtime smoke, Publint, and package type checks passed.
+- `git diff --check` and repository integrity checks passed.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "resolutions": {
     "braces": "3.0.3",
+    "js-yaml": "4.2.0",
     "lodash": "4.18.1",
     "minimatch/brace-expansion": "1.1.15",
     "undici": "6.27.0"

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -323,6 +323,9 @@ if (planPaths.includes(yarnPackageManagerPlanPath)) {
     if (!packageJson.scripts?.verify?.includes('yarn npm audit --all --recursive --severity high')) {
       errors.push(`${packageJsonPath} verify must run the Yarn 4 recursive high-severity audit`)
     }
+    if (packageJson.resolutions?.['js-yaml'] !== '4.2.0') {
+      errors.push(`${packageJsonPath} must pin patched js-yaml 4.2.0 across legacy coverage tooling`)
+    }
     if (packageJson.engines?.node !== '>=16.0') {
       errors.push(`${packageJsonPath} must preserve the published Node >=16.0 runtime floor`)
     }

--- a/test/lib/package-root.test.js
+++ b/test/lib/package-root.test.js
@@ -21,6 +21,10 @@ it('marks the published package as side-effect free', () => {
   expect(packageJson.sideEffects).toBe(false)
 })
 
+it('pins the patched YAML parser across legacy coverage tooling', () => {
+  expect(packageJson.resolutions['js-yaml']).toBe('4.2.0')
+})
+
 it('keeps documentation deployment explicit and separate from publishing', () => {
   expect(packageJson.scripts.prepublish).toBeUndefined()
   expect(packageJson.scripts.publish).toBeUndefined()

--- a/test/scripts/check-docs-plan.test.js
+++ b/test/scripts/check-docs-plan.test.js
@@ -126,6 +126,7 @@ const writeYarnPackageManagerBoundary = (projectPath, overrides = {}) => {
   const packageJson = {
     packageManager: 'yarn@4.17.0',
     engines: { node: '>=16.0' },
+    resolutions: { 'js-yaml': '4.2.0' },
     scripts: { verify: 'yarn npm audit --all --recursive --severity high' },
     ...overrides,
   }
@@ -237,6 +238,7 @@ describe('check-docs-plan script', () => {
     writeYarnPackageManagerBoundary(projectPath, {
       packageManager: 'yarn@1.22.22',
       engines: { node: '>=20.0' },
+      resolutions: { 'js-yaml': '3.14.2' },
       scripts: { verify: 'yarn audit' },
     })
     writeFileSync(path.join(projectPath, '.yarnrc.yml'), 'nodeLinker: pnp\n')
@@ -257,6 +259,7 @@ describe('check-docs-plan script', () => {
     expect(stderr).toContain(`${ciWorkflowPath} must include docker run --rm --network none`)
     expect(stderr).toContain(`${packageJsonPath} must pin packageManager to yarn@4.17.0`)
     expect(stderr).toContain(`${packageJsonPath} verify must run the Yarn 4 recursive high-severity audit`)
+    expect(stderr).toContain(`${packageJsonPath} must pin patched js-yaml 4.2.0 across legacy coverage tooling`)
     expect(stderr).toContain(`${packageJsonPath} must preserve the published Node >=16.0 runtime floor`)
     expect(stderr).toContain(`${yarnConfigPath} must preserve the node-modules linker`)
     expect(stderr).toContain(`${yarnPackageManagerPlanPath} must preserve completed evidence: Node 20`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4026,15 +4026,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
-  languageName: node
-  linkType: hard
-
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -5445,16 +5436,6 @@ __metadata:
     acorn-jsx: "npm:^5.3.2"
     eslint-visitor-keys: "npm:^4.2.1"
   checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
-  languageName: node
-  linkType: hard
-
-"esprima@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "esprima@npm:4.0.1"
-  bin:
-    esparse: ./bin/esparse.js
-    esvalidate: ./bin/esvalidate.js
-  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
   languageName: node
   linkType: hard
 
@@ -6968,19 +6949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.1":
+"js-yaml@npm:4.2.0":
   version: 4.2.0
   resolution: "js-yaml@npm:4.2.0"
   dependencies:
@@ -8750,13 +8719,6 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- pin `js-yaml` 4.2.0 across the legacy coverage dependency graph
- regenerate the Yarn 4 lockfile so no 3.x parser remains
- enforce the patched resolution in package and documentation-contract tests
- document the security boundary and completed verification

## Context

Dependabot's default-branch updater reported `security_update_not_possible` for GHSA-h67p-54hq-rp68 because the transitive `js-yaml` 3.x range could not reach the patched 4.2.0 release without a root resolution.

## Verification

- `make check` on Node 20.19.5
- `make check` on Node 24.16.0
- 400 tests, 16 suites, 2 snapshots
- 100% executable coverage
- recursive high-severity Yarn audit: no suggestions
- package contents, Node runtime smoke, Publint, and Are the Types Wrong checks
- four hostile interaction mutations rejected
- `git diff --check`
- `git fsck --strict`

## Baseline

The locked dependency graph still resolved a transitive YAML parser version with a published security issue despite the application and package checks otherwise passing.

## Improvements

- Pins the maintained transitive YAML parser through the existing Yarn resolution mechanism.
- Regenerates the immutable lockfile without changing the package API or runtime behavior.

## Validation

- Immutable Yarn installation, full package verification, audit, 400 tests, package linting, and distribution drift checks passed.
- Exact-head Node 20/24 package jobs, Node 16 artifact runtime smoke, and CodeQL passed after merge.

## Risk

This is a transitive dependency override. The public booking-selector API and source behavior are unchanged, but future dependency refreshes must keep the resolution compatible with the toolchain.

## Follow-Ups

- Remove the override only when the direct dependency graph naturally resolves an equal or newer reviewed version.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this is a package dependency repair with no repository-managed service. Healthy signals are immutable install, audit, package tests, artifact smoke, and CodeQL remaining green. Owner: repository maintainer; validation window: every push and pull request.
