### PR TITLE
docs: clarify booking selector registry source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@
 
 - `dist/` contains generated or packaged output; prefer changing source and rebuilding.
 - Deployment or publish scripts exist; do not run them unless explicitly asked.
+- npm `latest` is the historical 2020 `1.0.2` artifact, not the current
+  default-branch source; do not describe it as the current package release.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,32 @@
 # Changes
 
+## 2026-06-25 12:28 PDT - P2 - Clarify npm registry source boundary
+
+- Documented that npm `latest` still resolves to the historical `1.0.2`
+  artifact published on April 12, 2020 rather than the current default branch.
+- Recorded the registry artifact's React 15/16, styled-components 2/3, and Node
+  greater-than-8 boundary alongside the current React 18/19, styled-components
+  5/6, Node 16+, exports, types, accessibility, and verification surface.
+- Labeled the existing install command as historical-package guidance and
+  directed current-source evaluation to a reviewed repository commit plus the
+  Node 20+/Yarn 4 development workflow.
+- Added a red-first dependency-free docs contract and completed maintenance
+  plan. The checker first rejected the absent plan and five README fragments;
+  four hostile mutations then rejected weakened registry age, source
+  distinction, historical-install labeling, and future-release requirements.
+- The first green attempt exposed Markdown line-wrap sensitivity and was fixed
+  by normalizing prose whitespace. The first source mutation did not alter the
+  wrapped phrase, so its whitespace-aware rerun supplied the intended evidence.
+- The local full-gate attempt stopped because this host has Node 18 and no
+  Corepack; hosted Node 16/20/24 remains authoritative.
+- An isolated Node 20.19.5/Corepack 0.33.0/Yarn 4.17.0 toolchain then completed
+  immutable installation, the focused 17-test docs-plan suite, all 42 Make
+  authority cases, 400 Jest tests with 100% covered source, review mutations,
+  high-severity audit, package contents/runtime lint, publint, and type-package
+  analysis. The first full rerun found only Prettier layout in the checker;
+  formatting was corrected and the complete rerun passed.
+- A full build left checked-in `dist` unchanged, and `git diff --check` passed.
+
 ## 2026-06-21
 
 - Hardened all five pre-existing Make gates against caller-controlled root and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,10 @@
   analysis. The first full rerun found only Prettier layout in the checker;
   formatting was corrected and the complete rerun passed.
 - A full build left checked-in `dist` unchanged, and `git diff --check` passed.
+- Exact-head Codex review found the shorthand `styled-components 2/3`
+  incorrectly implied an upper bound; the registry's published
+  `>=2.0 || >=3.0` range is now documented as effectively `>=2.0` and enforced
+  by the docs contract.
 
 ## 2026-06-21
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,10 @@
 
 - Documented that npm `latest` still resolves to the historical `1.0.2`
   artifact published on April 12, 2020 rather than the current default branch.
-- Recorded the registry artifact's React 15/16, styled-components 2/3, and Node
-  greater-than-8 boundary alongside the current React 18/19, styled-components
-  5/6, Node 16+, exports, types, accessibility, and verification surface.
+- Recorded the registry artifact's exact React and styled-components peer
+  ranges plus Node greater-than-8 boundary alongside the current React 18/19,
+  styled-components 5/6, Node 16+, exports, types, accessibility, and
+  verification surface.
 - Labeled the existing install command as historical-package guidance and
   directed current-source evaluation to a reviewed repository commit plus the
   Node 20+/Yarn 4 development workflow.
@@ -30,6 +31,10 @@
   incorrectly implied an upper bound; the registry's published
   `>=2.0 || >=3.0` range is now documented as effectively `>=2.0` and enforced
   by the docs contract.
+- Follow-up review found deleting the plan disabled the boundary checks and the
+  plan mentioned gate commands only as earlier missing evidence. The actual
+  package repository now requires the plan, and the successful `corepack yarn
+verify` and `make check` runs are recorded explicitly.
 
 ## 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ### Registry Source Boundary
 
 npm `latest` still resolves to `1.0.2`, published on April 12, 2020. That
-historical registry artifact declares React 15/16, styled-components 2/3, and
+historical registry artifact declares React `>=15.5 && <=16.0`,
+styled-components `>=2.0 || >=3.0` (effectively `>=2.0`), and
 Node greater than 8; it does not contain the current package exports,
 TypeScript declarations, keyboard behavior, or verification stack. The
 registry package is not the current default-branch source.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,22 @@
 
 ## Getting Started
 
+### Registry Source Boundary
+
+npm `latest` still resolves to `1.0.2`, published on April 12, 2020. That
+historical registry artifact declares React 15/16, styled-components 2/3, and
+Node greater than 8; it does not contain the current package exports,
+TypeScript declarations, keyboard behavior, or verification stack. The
+registry package is not the current default-branch source.
+
+Use the install command below only when you intentionally need the historical registry package.
+
 ```bash
 yarn add react-booking-selector styled-components
 ```
+
+To evaluate current source, check out a reviewed repository commit and use the
+Node 20+/Yarn 4 development commands documented below. A future current-source release needs a new version and a reviewed publish.
 
 TypeScript declarations are included for both the default export and the named `BookingSelector` export.
 
@@ -351,6 +364,7 @@ See `docs/plans/2026-06-19-listener-and-roving-focus-review.md` for failed-clean
 See `docs/plans/2026-06-20-js-yaml-security-resolution.md` for the patched transitive YAML parser boundary.
 
 See `docs/plans/2026-06-21-safe-make-root.md` for fail-closed Make root resolution and regression coverage.
+See `docs/plans/2026-06-25-registry-source-boundary.md` for the npm registry and current-source distinction.
 See `docs/plans/2026-06-09-minute-unique-selection.md` for minute-unique selection payload handling.
 See `docs/plans/2026-06-09-docs-plan-readme-references.md` for README plan-link coverage.
 See `docs/plans/2026-06-09-docs-plan-readme-unique-references.md` for unique README plan-link coverage.

--- a/VISION.md
+++ b/VISION.md
@@ -58,6 +58,8 @@ Next priorities:
   boundary updates.
 - Keep peer dependency ranges aligned with supported React and styled-components
   majors.
+- Keep npm `latest` and the current default-branch source clearly distinguished
+  until a new reviewed package version is published.
 - Revisit the ESLint 10 major when the active parser and plugin peer ranges
   support it.
 

--- a/docs/plans/2026-06-25-registry-source-boundary.md
+++ b/docs/plans/2026-06-25-registry-source-boundary.md
@@ -59,9 +59,16 @@ peer dependency ranges.
   historical-install labeling, and future-release requirements. The first
   source mutation did not alter wrapped Markdown, so a whitespace-aware rerun
   provided the intended rejection evidence.
-- `node scripts/check-docs-plan.js` and `git diff --check` passed locally. This
-  host has Node 18 and no Corepack, so complete package verification remains a
-  hosted Node 20/24 responsibility.
+- `node scripts/check-docs-plan.js` and `git diff --check` passed locally.
+- With isolated Node 20.19.5, Corepack 0.33.0, and Yarn 4.17.0,
+  `corepack yarn verify` passed 400 Jest tests, coverage, review mutations,
+  audit, package contents/runtime checks, publint, and type-package analysis.
+- With that same toolchain, `make check` passed all 42 Make authority cases and
+  the complete verification graph. A full build left `dist` unchanged.
 - Exact-head Codex review found that shorthand `styled-components 2/3` implied
   an upper bound absent from the published `>=2.0 || >=3.0` range. README and
   the checker now state its effective `>=2.0` meaning precisely.
+- Follow-up exact-head review found the plan could be deleted to disable its
+  checks and that successful gates were recorded only indirectly. The checker
+  now requires the plan for the actual package repository, and this section
+  records the successful commands explicitly.

--- a/docs/plans/2026-06-25-registry-source-boundary.md
+++ b/docs/plans/2026-06-25-registry-source-boundary.md
@@ -1,0 +1,64 @@
+# Registry Source Boundary
+
+## Status: Completed
+
+## Goal
+
+Prevent consumers from assuming the npm `latest` package contains the current
+default-branch component, package exports, accessibility behavior, or supported
+peer dependency ranges.
+
+## Evidence
+
+- The npm registry `latest` dist-tag resolves to version `1.0.2`, published on
+  April 12, 2020.
+- The registry package declares React `>=15.5 && <=16.0`, styled-components
+  `>=2.0 || >=3.0`, and Node `>8.0`.
+- The current default branch still carries version `1.0.2` metadata but declares
+  React 18/19, styled-components 5/6, Node 16+, CommonJS and ESM exports,
+  TypeScript declarations, keyboard navigation, and current hosted verification.
+- The historical registry tarball publishes source, tests, editor metadata,
+  old docs bundles, and no current exports or TypeScript declaration surface.
+
+## Decisions
+
+- Label the existing install command as historical registry-package guidance.
+- State that npm `latest` is not the current default-branch source.
+- Direct current-source evaluation to a reviewed repository commit and local
+  build rather than inventing an unverified Git dependency command.
+- Require a new version and reviewed publish before claiming a current registry
+  release.
+- Add an exact dependency-free README contract to `docs:check`.
+
+## Verification
+
+- Run `node scripts/check-docs-plan.js` before the README change and capture the
+  missing boundary failures.
+- Exercise hostile mutations that remove the registry age, source distinction,
+  historical-install label, or future-release requirement.
+- Run the focused docs-plan tests, complete package verification, hosted Node
+  16/20/24 gates, and exact-head review before merge.
+
+## Risks
+
+- The root package version remains equal to the registry version; this change
+  prevents overclaims but does not publish current source.
+- Repository source needs the documented Node 20+/Yarn 4 development toolchain;
+  users should not mistake a source checkout for a ready registry artifact.
+
+## Verification Result
+
+- The first `node scripts/check-docs-plan.js` run rejected the missing plan and
+  all five README boundary fragments.
+- After adding the plan, the checker rejected the five missing fragments,
+  incomplete status, missing `corepack yarn verify` and `make check` evidence,
+  and absent README plan reference.
+- The first green attempt exposed raw Markdown line-wrap sensitivity; normalized
+  prose matching fixed that without weakening exact content.
+- Four hostile mutations rejected weakened registry age, source distinction,
+  historical-install labeling, and future-release requirements. The first
+  source mutation did not alter wrapped Markdown, so a whitespace-aware rerun
+  provided the intended rejection evidence.
+- `node scripts/check-docs-plan.js` and `git diff --check` passed locally. This
+  host has Node 18 and no Corepack, so complete package verification remains a
+  hosted Node 20/24 responsibility.

--- a/docs/plans/2026-06-25-registry-source-boundary.md
+++ b/docs/plans/2026-06-25-registry-source-boundary.md
@@ -62,3 +62,6 @@ peer dependency ranges.
 - `node scripts/check-docs-plan.js` and `git diff --check` passed locally. This
   host has Node 18 and no Corepack, so complete package verification remains a
   hosted Node 20/24 responsibility.
+- Exact-head Codex review found that shorthand `styled-components 2/3` implied
+  an upper bound absent from the published `>=2.0 || >=3.0` range. README and
+  the checker now state its effective `>=2.0` meaning precisely.

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -86,6 +86,7 @@ if (planPaths.includes(registrySourceBoundaryPlanPath)) {
   for (const fragment of [
     '### Registry Source Boundary',
     'npm `latest` still resolves to `1.0.2`, published on April 12, 2020',
+    'styled-components `>=2.0 || >=3.0` (effectively `>=2.0`)',
     'The registry package is not the current default-branch source.',
     'Use the install command below only when you intentionally need the historical registry package.',
     'A future current-source release needs a new version and a reviewed publish.',

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -25,6 +25,7 @@ const planDirFsPath = toFsPath(planDir)
 const makefile = fs.existsSync('Makefile') ? fs.readFileSync('Makefile', 'utf8') : ''
 const readme = fs.existsSync('README.md') ? fs.readFileSync('README.md', 'utf8') : ''
 const normalizedReadme = readme.replace(/\s+/gu, ' ')
+const packageName = fs.existsSync(packageJsonPath) ? JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name : null
 
 const errors = []
 const planFilenamePattern = /^(\d{4})-(\d{2})-(\d{2})-[-\w.]+\.md$/u
@@ -82,7 +83,10 @@ if (!planPaths.includes(ciPlanPath)) {
   errors.push(`${ciPlanPath} is missing`)
 }
 
-if (planPaths.includes(registrySourceBoundaryPlanPath)) {
+if (packageName === 'react-booking-selector') {
+  if (!planPaths.includes(registrySourceBoundaryPlanPath)) {
+    errors.push(`${registrySourceBoundaryPlanPath} is missing`)
+  }
   for (const fragment of [
     '### Registry Source Boundary',
     'npm `latest` still resolves to `1.0.2`, published on April 12, 2020',

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -14,6 +14,7 @@ const locationIndependentMakePlanPath = toPlanPath('2026-06-14-location-independ
 const yarnPackageManagerPlanPath = toPlanPath('2026-06-15-yarn-4-package-manager.md')
 const explicitDocsDeploymentPlanPath = toPlanPath('2026-06-15-explicit-docs-deployment.md')
 const documentListenerMigrationPlanPath = toPlanPath('2026-06-16-document-mouseup-listener-migration.md')
+const registrySourceBoundaryPlanPath = toPlanPath('2026-06-25-registry-source-boundary.md')
 const ciWorkflowPath = '.github/workflows/check.yml'
 const workflowDir = '.github/workflows'
 const codeownersPath = '.github/CODEOWNERS'
@@ -23,6 +24,7 @@ const yarnConfigPath = '.yarnrc.yml'
 const planDirFsPath = toFsPath(planDir)
 const makefile = fs.existsSync('Makefile') ? fs.readFileSync('Makefile', 'utf8') : ''
 const readme = fs.existsSync('README.md') ? fs.readFileSync('README.md', 'utf8') : ''
+const normalizedReadme = readme.replace(/\s+/gu, ' ')
 
 const errors = []
 const planFilenamePattern = /^(\d{4})-(\d{2})-(\d{2})-[-\w.]+\.md$/u
@@ -78,6 +80,18 @@ if (!planPaths.includes(baselinePlanPath)) {
 
 if (!planPaths.includes(ciPlanPath)) {
   errors.push(`${ciPlanPath} is missing`)
+}
+
+if (planPaths.includes(registrySourceBoundaryPlanPath)) {
+  for (const fragment of [
+    '### Registry Source Boundary',
+    'npm `latest` still resolves to `1.0.2`, published on April 12, 2020',
+    'The registry package is not the current default-branch source.',
+    'Use the install command below only when you intentionally need the historical registry package.',
+    'A future current-source release needs a new version and a reviewed publish.',
+  ]) {
+    if (!normalizedReadme.includes(fragment)) errors.push(`README.md registry source boundary must include ${fragment}`)
+  }
 }
 
 if (planPaths.includes(ciPlanPath)) {


### PR DESCRIPTION
## Summary
- distinguish npm `latest` 1.0.2 from current default-branch source
- label the install command as historical registry-package guidance
- direct current-source evaluation to reviewed commits and the Node 20+/Yarn 4 workflow
- add a red-first docs contract and completed verification plan

## Verification
- four hostile README mutations rejected
- focused docs-plan suite: 17 tests
- full `make check`: 400 tests, 100% covered source, audit, package/runtime/type lint
- full build with no `dist` drift
- `git diff --check`
