### PR TITLE
Ignore local repository metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ yarn-error.log
 dev
 coverage
 .vscode/
+.explore/
 .yarn/
 .node16-package/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@
 ## Safety and gotchas
 
 - `dist/` contains generated or packaged output; prefer changing source and rebuilding.
+- `.explore/` contains local maintainer intelligence; keep it ignored and move
+  durable decisions into tracked plans, changes, policies, tests, or source.
 - Deployment or publish scripts exist; do not run them unless explicitly asked.
 - npm `latest` is the historical 2020 `1.0.2` artifact, not the current
   default-branch source; do not describe it as the current package release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,70 @@
 # Changes
 
+## 2026-06-25 15:15 PDT - P2 - Ignore local repository metadata
+
+### Summary
+
+Kept repository-local `.explore/` intelligence out of working-tree status and
+tracked source while strengthening the existing `.vscode/` boundary.
+
+### Work completed
+
+- Added the exact active `.explore/` ignore rule.
+- Reworked the package-root test to require active patterns, effective Git
+  ignore behavior, and an empty tracked metadata set.
+- Removed the filesystem-existence filter that could hide deleted tracked
+  editor or intelligence files.
+- Added durable setup, contributor, roadmap, and maintenance-plan guidance.
+
+### Threads
+
+- Started: local maintainer-intelligence ignore boundary.
+- Continued: editor metadata and package-root repository hygiene.
+- Stopped: none.
+
+### Files changed
+
+- `.gitignore` — ignored `.explore/`.
+- `test/lib/package-root.test.js` — enforced active, effective, and index-aware
+  local metadata boundaries.
+- `README.md` — documented local-only metadata and durable evidence.
+- `AGENTS.md` — added the contributor maintenance rule.
+- `VISION.md` — added the tracked-source guardrail.
+- `docs/plans/2026-06-25-local-repository-metadata-ignore.md` — recorded the
+  evidence, decisions, verification, and risk.
+- `CHANGES.md` — recorded this P2 cycle.
+
+### Validation
+
+- Red-first package-root test — failed because `.explore/` was not an active
+  ignore pattern.
+- Focused docs-plan and package-root suites passed 29 tests; formatting and
+  lint checks passed.
+- `make check` passed 42 Make target/authority cases, 28 canonical plans, 400
+  Jest tests with 100% covered-source thresholds, four review mutations, the
+  high-severity audit, package contents/runtime checks, publint, and type-package
+  analysis under Node 20.19.5/Corepack 0.33.0/Yarn 4.17.0.
+- `make build` reproduced the checked-in library and documentation output with
+  no `dist` drift; `git diff --check` passed.
+- Hosted and exact-head review validation is pending.
+
+### Bugs / findings
+
+- P2: persistent maintainer intelligence appeared as untracked package source
+  and could be staged or published accidentally.
+- P2: the previous tracked-editor check filtered by filesystem existence and
+  could miss deleted paths still present in Git's index.
+
+### Blockers
+
+- The system Node is 18 and has no Corepack; an isolated Node 20.19.5/Corepack
+  0.33.0/Yarn 4.17.0 toolchain is available for local verification.
+
+### Next action
+
+- Complete focused and full gates, exact-head review, and hosted Node/CodeQL
+  checks; merge only when all evidence is clean.
+
 ## 2026-06-25 12:28 PDT - P2 - Clarify npm registry source boundary
 
 - Documented that npm `latest` still resolves to the historical `1.0.2`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,7 +46,11 @@ tracked source while strengthening the existing `.vscode/` boundary.
   analysis under Node 20.19.5/Corepack 0.33.0/Yarn 4.17.0.
 - `make build` reproduced the checked-in library and documentation output with
   no `dist` drift; `git diff --check` passed.
-- Hosted and exact-head review validation is pending.
+- Exact-head Codex review — clean on
+  `edaa70e1496886a8ee278d270385605705738272` with no actionable findings.
+- Both push and pull-request Node 16 artifact jobs passed, and both Node 20/24
+  full verification matrices passed with clean regenerated `dist` output.
+- CodeQL Actions and JavaScript/TypeScript analysis passed.
 
 ### Bugs / findings
 
@@ -62,8 +66,8 @@ tracked source while strengthening the existing `.vscode/` boundary.
 
 ### Next action
 
-- Complete focused and full gates, exact-head review, and hosted Node/CodeQL
-  checks; merge only when all evidence is clean.
+- Rerun exact-head review and hosted checks for this evidence-only update, then
+  merge if they remain clean.
 
 ## 2026-06-25 12:28 PDT - P2 - Clarify npm registry source boundary
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ request, or manual dispatch.
 Package publication and documentation deployment are separate maintainer
 actions: publishing never runs a deploy lifecycle hook, and documentation is
 deployed only through an explicit `corepack yarn docs:deploy` invocation.
+Repository-local `.vscode/` editor state and `.explore/` maintainer intelligence
+are ignored, effectively excluded by Git, and forbidden from the tracked source
+set. Durable decisions belong in reviewed plans, changes, policies, tests, or
+source rather than local metadata.
 
 See `docs/plans/2026-06-08-react-booking-selector-baseline.md` for the current package verification baseline.
 See `docs/plans/2026-06-08-docs-plan-inventory-check.md` for the docs-plan inventory baseline.
@@ -366,6 +370,7 @@ See `docs/plans/2026-06-20-js-yaml-security-resolution.md` for the patched trans
 
 See `docs/plans/2026-06-21-safe-make-root.md` for fail-closed Make root resolution and regression coverage.
 See `docs/plans/2026-06-25-registry-source-boundary.md` for the npm registry and current-source distinction.
+See `docs/plans/2026-06-25-local-repository-metadata-ignore.md` for effective local metadata ignore and index coverage.
 See `docs/plans/2026-06-09-minute-unique-selection.md` for minute-unique selection payload handling.
 See `docs/plans/2026-06-09-docs-plan-readme-references.md` for README plan-link coverage.
 See `docs/plans/2026-06-09-docs-plan-readme-unique-references.md` for unique README plan-link coverage.

--- a/VISION.md
+++ b/VISION.md
@@ -32,6 +32,7 @@ Priority:
 - Keep every canonical maintenance plan linked exactly once from README with
   slash-separated `docs/plans` paths
 - Keep local editor metadata out of package verification inputs
+- Keep local maintainer intelligence ignored and out of the tracked source set
 - Keep the package manifest files allowlist aligned with the intended published
   package surface
 - Reject duplicate package file entries in manifest and dry-run package checks

--- a/docs/plans/2026-06-25-local-repository-metadata-ignore.md
+++ b/docs/plans/2026-06-25-local-repository-metadata-ignore.md
@@ -1,0 +1,57 @@
+# Local Repository Metadata Ignore
+
+## Status: Completed
+
+## Context
+
+The checkout persists maintainer working notes under `.explore/`, but the
+directory was not ignored. Every synchronized repository therefore appeared
+dirty, and local intelligence could be staged or published accidentally.
+
+The existing package-root test covered `.vscode/` only through raw ignore text
+and filtered tracked paths by filesystem existence. That did not prove Git's
+effective ordered-rule behavior and could miss deleted files still present in
+the index.
+
+## Objectives
+
+- Add the exact active `.explore/` ignore rule.
+- Verify Git effectively ignores local metadata directories and a representative
+  intelligence file.
+- Reject every tracked `.vscode` or `.explore` path without filtering by current
+  filesystem existence.
+- Keep local metadata outside formatting, package, and durable review evidence.
+
+## Work Completed
+
+- Added `.explore/` to `.gitignore`.
+- Strengthened the package-root contract to parse active patterns, call pinned
+  `/usr/bin/git check-ignore`, and query tracked metadata with `git ls-files`.
+- Preserved the existing `.vscode/` formatting-input exclusions.
+- Updated repository guidance and this canonical maintenance record.
+
+## Verification
+
+- The focused package-root suite failed first because `.explore/` was absent.
+- `corepack yarn verify`
+- `make check`
+- `git diff --check`
+
+## Risks
+
+- Ignored local notes are not shared through Git. Durable technical decisions
+  must be copied into tracked plans, changes, policies, tests, or source.
+- The contract relies on `/usr/bin/git`, matching the hosted Ubuntu and common
+  macOS system-tool locations used by this repository's verification policy.
+- This change does not alter the component API, booking behavior, package
+  contents, generated distribution, or publication workflow.
+
+## Verification Result
+
+- The red-first package-root suite rejected the absent `.explore/` rule.
+- The focused docs-plan/package-root suites passed 29 tests, formatting, and
+  lint checks.
+- `corepack yarn verify` and `make check` passed 42 Make authority cases, 400
+  Jest tests with full covered-source thresholds, hostile review mutations,
+  audit, package contents/runtime checks, publint, and type-package analysis.
+- `make build` left checked-in `dist` unchanged, and `git diff --check` passed.

--- a/docs/plans/2026-06-25-local-repository-metadata-ignore.md
+++ b/docs/plans/2026-06-25-local-repository-metadata-ignore.md
@@ -55,3 +55,5 @@ the index.
   Jest tests with full covered-source thresholds, hostile review mutations,
   audit, package contents/runtime checks, publint, and type-package analysis.
 - `make build` left checked-in `dist` unchanged, and `git diff --check` passed.
+- Exact-head Codex review was clean. Push and pull-request Node 16/20/24 jobs,
+  clean distribution checks, and CodeQL Actions/JavaScript analysis passed.

--- a/test/lib/package-root.test.js
+++ b/test/lib/package-root.test.js
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { existsSync, readFileSync } from 'fs'
+import { readFileSync } from 'fs'
 
 import BookingSelector, { BookingSelector as NamedBookingSelector } from 'react-booking-selector'
 import packageJson from 'react-booking-selector/package.json'
@@ -82,16 +82,28 @@ it('uses the node-modules linker for repository tooling', () => {
   expect(readFileSync('.yarnrc.yml', 'utf8')).toBe('nodeLinker: node-modules\n')
 })
 
-it('keeps local editor metadata out of verification inputs', () => {
-  const gitignore = readFileSync('.gitignore', 'utf8')
-  const trackedEditorFiles = execFileSync('git', ['ls-files', '.vscode'], {
+it('keeps local repository metadata out of verification inputs', () => {
+  const activeGitignorePatterns = new Set(
+    readFileSync('.gitignore', 'utf8')
+      .split(/\r?\n/u)
+      .filter((line) => line && !line.startsWith('#')),
+  )
+  const trackedMetadataFiles = execFileSync('/usr/bin/git', ['ls-files', '--', '.vscode', '.explore'], {
     encoding: 'utf8',
   })
     .split('\n')
-    .filter((filePath) => filePath && existsSync(filePath))
+    .filter(Boolean)
 
-  expect(gitignore).toContain('.vscode/')
-  expect(trackedEditorFiles).toEqual([])
+  expect(activeGitignorePatterns).toContain('.vscode/')
+  expect(activeGitignorePatterns).toContain('.explore/')
+  for (const metadataPath of ['.vscode/', '.explore/', '.explore/REPO_MAP.md']) {
+    expect(() =>
+      execFileSync('/usr/bin/git', ['check-ignore', '--quiet', metadataPath], {
+        stdio: 'ignore',
+      }),
+    ).not.toThrow()
+  }
+  expect(trackedMetadataFiles).toEqual([])
   expect(packageJson.scripts.format).not.toContain('.vscode')
   expect(packageJson.scripts['format:check']).not.toContain('.vscode')
 })


### PR DESCRIPTION
## Summary
- ignore maintainer-local `.explore/` intelligence
- strengthen repository-root policy to require active and effective metadata ignores
- reject tracked `.vscode` or `.explore` paths without filesystem-existence filtering

## Red / green evidence
- focused package-root test failed before `.explore/` was added
- focused docs-plan/package-root suites pass 29 tests
- `make check` passes 42 Make authority cases and 400 Jest tests at full covered-source thresholds
- review mutations, audit, package contents/runtime checks, publint, and type-package analysis pass
- `make build` leaves checked-in `dist` unchanged

## Risk
No component API, selection behavior, package contents, generated output, or publish workflow changes.
