### PR TITLE
Fail closed when the verify chain drops a gate link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changes
 
+## 2026-07-17 12:00 UTC - P1 - verify chain contract
+
+### Summary
+
+Made the repository gate fail closed when a link is dropped from the canonical
+`verify` chain. Previously the assertions covering the chain ran inside the chain
+itself, so removing `yarn cover:check` also removed the only check that would
+have noticed.
+
+### Work completed
+
+- Asserted the ordered `verify` chain and the `cover:check` exit-status
+  propagation from `scripts/test-makefile-root.sh`, which `make` runs as a
+  prerequisite of `verify` and which survives an emptied chain
+- Compared parsed `package.json` script values so duplicate JSON keys cannot
+  satisfy the contract with dead text
+- Rejected `|| true`, `|| exit 0`, `|| :`, `; true`, `--passWithNoTests`, and
+  `continue-on-error` in any package script
+
 ## 2026-06-26 14:00 UTC - P1 - stale document mouseup ownership
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -393,3 +393,4 @@ See `docs/plans/2026-06-10-package-file-mode-check.md` for packed-file executabl
 See `docs/plans/2026-06-10-hosted-verification.md` for the pinned Node 20/24 verification and clean distribution gate.
 See `docs/plans/2026-06-12-package-size-budget.md` for fail-closed packed, unpacked, and per-file size ceilings.
 See `docs/plans/2026-06-12-node16-package-runtime.md` for the advertised runtime-floor package smoke.
+See `docs/plans/2026-07-17-verify-chain-contract.md` for the fail-closed contract on the canonical verify chain.

--- a/docs/plans/2026-07-17-verify-chain-contract.md
+++ b/docs/plans/2026-07-17-verify-chain-contract.md
@@ -1,0 +1,91 @@
+# Verify Chain Contract Implementation Plan
+
+**Goal:** Make the repository gate fail closed when a link is dropped from the canonical `verify` chain, including the links that carry the test suite and the hostile-mutation harness.
+
+**Architecture:** `make check` reaches every quality command only through `package.json`'s `verify` chain. The checks that would notice a missing link (`test/lib/package-root.test.js`) run inside that chain via `yarn cover:check`, so removing `cover:check` also removes the only observer of the removal. Assert the chain from `scripts/test-makefile-root.sh`, which `make` runs as a prerequisite of `verify` before `corepack yarn verify` and which therefore survives an emptied chain. Compare parsed `scripts` values so duplicate JSON keys cannot satisfy the contract with dead text. Add a complementary failure-suppression scan to `scripts/check-docs-plan.js`. Do not change component behavior, publication, deployment, or the set of commands the gate runs.
+
+**Tech Stack:** Node.js 20/24, Yarn 4, Jest, GNU Make.
+
+---
+
+## Status: Completed
+
+### Task 1: Prove the Missing Gate
+
+**Files:**
+
+- Verify only.
+
+1. Remove `yarn cover:check` and `yarn review:mutations` from `verify` and confirm `make check` still exits 0 with no test suite executed.
+2. Replace `exit $status` with `exit 0` in `cover:check`, break a unit-tested pure function, and confirm `make check` prints the failures and still exits 0.
+
+### Task 2: Assert the Chain on the Surviving Channel
+
+**Files:**
+
+- Modify: `scripts/test-makefile-root.sh`
+
+1. Read `verify` and `cover:check` from `package.json` with a JSON parser.
+2. Fail closed when the ordered chain or the `cover:check` exit-status propagation drifts from the reviewed contract.
+
+### Task 3: Reject Failure Suppression in Package Scripts
+
+**Files:**
+
+- Modify: `scripts/check-docs-plan.js`
+
+1. Compare the parsed `verify` chain against the reviewed ordered contract.
+2. Pin the reviewed command for each script that wires the gate to a checker.
+3. Reject `|| true`, `|| exit 0`, `|| :`, `; true`, `--passWithNoTests`, and `continue-on-error` in any package script.
+
+### Task 4: Synchronize Maintainer Documentation
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-07-17-verify-chain-contract.md`
+
+1. Link this plan exactly once from the README plan inventory.
+2. Record the red/green evidence and review status.
+
+### Task 5: Validate the Full Gate
+
+**Files:**
+
+- Verify only.
+
+1. Run `corepack yarn verify`.
+2. Run `make check` and `make build` from the checkout.
+3. Confirm the checked-in `dist/` tree remains unchanged.
+
+## Verification Completed
+
+- Before the change, stripping `yarn cover:check` and `yarn review:mutations`
+  from `verify` left `make check` exiting 0 with zero test suites executed. The
+  only assertions covering the chain live in `test/lib/package-root.test.js`,
+  which runs inside `yarn cover:check`, so the removal also removed its own
+  detector. Stripping `yarn docs:smoke` alone was caught at
+  `test/lib/package-root.test.js:45`; stripping it together with
+  `yarn cover:check` was not caught at all.
+- Before the change, rewriting `cover:check` to end in `exit 0` and breaking
+  `getDuplicateValues` in `scripts/check-package-contents.js` produced
+  `Tests: 3 failed, 400 passed` beside `Package contents check passed` and
+  `All good!` at `make check` exit 0.
+- After the change, `scripts/test-makefile-root.sh` rejects the dropped links,
+  the reordered chain, the `exit 0` neuter, a duplicate `verify` JSON key whose
+  last value guts the chain, and a `|| true` neuter. `make check` exits 2 for
+  each, before `corepack yarn verify` runs.
+- Removing `yarn docs:check` from `verify` to disable the `check-docs-plan.js`
+  contract is rejected by the root-test channel, which `make` runs as a
+  prerequisite of `verify`.
+- The packed, unpacked, and per-file size ceilings in
+  `scripts/check-package-contents.js` were probed and left unchanged: widening
+  `MAX_PACKED_SIZE_BYTES` to `128 * 1024` is rejected by the literal byte counts
+  asserted in the size-violation test, and respelling the same value as `65536`
+  is correctly accepted.
+- `make check` passed with 403 tests across 16 suites, five rejected hostile
+  mutations, Prettier, ESLint, type checks, audit, package-contents,
+  package-runtime, publint, and attw. `make build` passed and
+  `git diff --exit-code -- dist` reported no change.
+- Hosted Node 20/24 checks remain required before merge.

--- a/scripts/check-docs-plan.js
+++ b/scripts/check-docs-plan.js
@@ -366,6 +366,62 @@ for (const makeContract of makeContracts) {
   }
 }
 
+// The reviewed gate chain, in order. `make check` reaches every quality command only through this
+// chain, so a dropped or reordered link silently removes verification. Compare the parsed value so
+// duplicate `scripts` keys (last key wins in JSON) cannot satisfy this contract with dead text.
+const verifyChainContract = [
+  'yarn docs:check',
+  'yarn docs:smoke',
+  'yarn format:check',
+  'yarn lint',
+  'yarn types:check',
+  'yarn cover:check',
+  'yarn review:mutations',
+  'yarn npm audit --all --recursive --severity high',
+  'yarn pack:check',
+  'yarn package:runtime',
+  'yarn package:lint',
+]
+
+// Commands whose exit status is the gate. `cover:check` must propagate Jest's status after cleaning
+// coverage output; `exit 0` there reports failures and still passes.
+const gateScriptContracts = new Map([
+  ['cover:check', 'yarn lib:build && jest --coverage --runInBand; status=$?; rm -rf coverage; exit $status'],
+  ['review:mutations', 'node scripts/test-booking-selector-review-mutations.js'],
+  ['docs:check', 'node scripts/check-docs-plan.js'],
+  ['pack:check', 'node scripts/check-package-contents.js'],
+])
+
+const failureSuppressingFragments = ['|| true', '|| exit 0', '|| :', '; true', '--passWithNoTests', 'continue-on-error']
+
+if (packageName === 'react-booking-selector') {
+  const gateScripts = JSON.parse(fs.readFileSync(toFsPath(packageJsonPath), 'utf8')).scripts ?? {}
+  const verifyChain = (gateScripts.verify ?? '').split(' && ').map((command) => command.trim())
+
+  if (verifyChain.join(' && ') !== verifyChainContract.join(' && ')) {
+    errors.push(
+      `${packageJsonPath} verify must run the reviewed gate chain in order:\n` +
+        `  expected: ${verifyChainContract.join(' && ')}\n` +
+        `  found:    ${verifyChain.join(' && ')}`,
+    )
+  }
+
+  for (const [scriptName, expectedCommand] of gateScriptContracts) {
+    if (gateScripts[scriptName] !== expectedCommand) {
+      errors.push(`${packageJsonPath} ${scriptName} must preserve the reviewed command: ${expectedCommand}`)
+    }
+  }
+
+  for (const [scriptName, command] of Object.entries(gateScripts)) {
+    if (typeof command !== 'string') continue
+    for (const fragment of failureSuppressingFragments) {
+      if (command.includes(fragment)) {
+        errors.push(`${packageJsonPath} ${scriptName} must not suppress failures with ${fragment}`)
+      }
+    }
+  }
+}
+
 if (planPaths.includes(locationIndependentMakePlanPath)) {
   const locationIndependentMakePlan = fs.readFileSync(toFsPath(locationIndependentMakePlanPath), 'utf8')
   for (const evidence of ['Node 20', 'Node 24', 'unrelated directory', 'hostile mutations rejected']) {

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -224,4 +224,32 @@ if [ -e "$COMMAND_LOG" ]; then
   exit 1
 fi
 
-printf '%s\n' "Makefile root tests passed: 42 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, 2 multi-Makefile rejections, 5 MAKEFLAGS rejections, and 1 dollar-path fail-closed case"
+# `make check` runs this target as a prerequisite of `verify`, before `corepack yarn verify`, so this
+# is the only gate channel that still runs when the verify chain itself is emptied. Every quality
+# command is reached only through that chain, and the checks that would notice a dropped link all run
+# inside it, so the chain is asserted here rather than only from within itself. Values are read with
+# a JSON parser so duplicate `scripts` keys (last key wins) cannot satisfy the contract with dead text.
+EXPECTED_VERIFY_CHAIN='yarn docs:check && yarn docs:smoke && yarn format:check && yarn lint && yarn types:check && yarn cover:check && yarn review:mutations && yarn npm audit --all --recursive --severity high && yarn pack:check && yarn package:runtime && yarn package:lint'
+EXPECTED_COVER_CHECK='yarn lib:build && jest --coverage --runInBand; status=$?; rm -rf coverage; exit $status'
+read_script() {
+  (cd "$ROOT_DIR" && node -e 'const s = require("./package.json").scripts || {}; process.stdout.write(String(s[process.argv[1]] ?? ""))' "$1")
+}
+
+ACTUAL_VERIFY_CHAIN=$(read_script verify)
+if [ "$ACTUAL_VERIFY_CHAIN" != "$EXPECTED_VERIFY_CHAIN" ]; then
+  printf '%s\n' "package.json verify must run the reviewed gate chain in order" >&2
+  printf '  expected: %s\n' "$EXPECTED_VERIFY_CHAIN" >&2
+  printf '  found:    %s\n' "$ACTUAL_VERIFY_CHAIN" >&2
+  exit 1
+fi
+
+# cover:check carries the test suite and the coverage thresholds; its exit status is the gate.
+ACTUAL_COVER_CHECK=$(read_script cover:check)
+if [ "$ACTUAL_COVER_CHECK" != "$EXPECTED_COVER_CHECK" ]; then
+  printf '%s\n' "package.json cover:check must propagate the Jest exit status" >&2
+  printf '  expected: %s\n' "$EXPECTED_COVER_CHECK" >&2
+  printf '  found:    %s\n' "$ACTUAL_COVER_CHECK" >&2
+  exit 1
+fi
+
+printf '%s\n' "Makefile root tests passed: 42 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, 2 multi-Makefile rejections, 5 MAKEFLAGS rejections, 1 dollar-path fail-closed case, 1 verify-chain contract, and 1 cover:check exit-status contract"


### PR DESCRIPTION
## The gap

`make check` reaches every quality command only through `package.json`'s `verify` chain:

```
make check -> check: verify
  ├─ [A] root-test          <- make PREREQUISITE, runs before `yarn verify`
  └─ [B] corepack yarn verify
       docs:check && docs:smoke && format:check && lint && types:check
       && cover:check        <- the entire test suite + 100% coverage thresholds
       && review:mutations   <- the hostile-mutation harness
       && npm audit && pack:check && package:runtime && package:lint
```

The assertions covering that chain live in `test/lib/package-root.test.js`, which runs **inside** the chain via `yarn cover:check`. So the check that would notice a link disappearing is itself removed by removing the link. Before this change, `check-docs-plan.js` read `scripts.verify` at exactly one place (line 386) and pinned exactly one of the eleven links (the `npm audit` fragment). `cover:check` and `review:mutations` were pinned by nothing, anywhere:

```
$ grep -rn "cover:check" test/ scripts/
(no matches)
```

`2026-06-26-docs-smoke-verify-gate.md` established the right pattern — add the link to `verify`, plus "a root-contract test that fails if the gate is removed." That contract is in `package-root.test.js`, inside `cover:check`'s blast radius, so it protects `docs:smoke` only while `cover:check` still runs. This PR extends that pattern to the remaining links, on the one channel that survives.

## Measured evidence

Clean-tree baseline before any probe: `make check` exit 0, 403 tests, 5 mutations rejected.

| Mutation to the gate | Before | After |
|---|---|---|
| clean tree (no mutation) | exit 0 | **exit 0** — 403 tests, no false positive |
| strip `yarn cover:check && yarn review:mutations` from `verify` | **exit 0 MISS** — 0 test suites ran | exit 2 CAUGHT |
| also strip `docs:smoke` + `package:runtime` (4 links gone) | **exit 0 MISS** | exit 2 CAUGHT |
| strip `docs:smoke` **alone**, `cover:check` intact | exit 2 caught at `package-root.test.js:45` | exit 2 CAUGHT |
| `cover:check`: `exit $status` -> `exit 0`, plus a real 3-test failure | **exit 0 MISS** — printed `Tests: 3 failed, 400 passed` beside `Package contents check passed` / `All good!` | exit 1 CAUGHT |
| duplicate `verify` JSON key, last value guts the chain | **exit 0 MISS** — gutted chain kept the one pinned `npm audit` fragment and satisfied it | exit 1 CAUGHT |
| `yarn cover:check \|\| true` | textually invisible to every check (zero pins, grep-verified) | exit 1 CAUGHT |
| strip `yarn docs:check`, disabling the new contract itself | n/a | exit 2 CAUGHT by root-test, before `yarn verify` |
| rename package + strip `review:mutations` | n/a | exit 1 CAUGHT by root-test |

The two rows in bold that matter most: the gate reported failing tests and passed anyway, and the gate passed with no tests at all.

The third and fourth rows together are the mechanism — the verdict inverts on whether `cover:check` runs. `docs:smoke` removed alone is caught; `docs:smoke` removed *together with* `cover:check` is not, because the detector went with it.

## The fix

- **`scripts/test-makefile-root.sh`** — asserts the ordered `verify` chain and the `cover:check` exit-status propagation. `make` runs this target as a prerequisite of `verify`, before `corepack yarn verify`, so it still runs when the chain is emptied. This is deliberately not placed in `check-docs-plan.js` alone: that script *is* link 0 of the chain it would guard.
- **`scripts/check-docs-plan.js`** — complementary: pins the reviewed command for each script that wires the gate to a checker, and rejects `|| true`, `|| exit 0`, `|| :`, `; true`, `--passWithNoTests`, and `continue-on-error` in any package script.

Both read values through a JSON parser rather than matching text, so duplicate `scripts` keys (last key wins) cannot satisfy the contract with dead text — the duplicate-key row above.

The chain list appears in both files. That mirrors the existing convention where the Makefile contracts are pinned verbatim in both `check-docs-plan.js` (`makeContracts`) and `package-root.test.js`, and it makes the two guards mutually locking: `check-docs-plan.js` pins the Makefile's `verify: root-test` line so root-test cannot be unhooked, and root-test pins `yarn docs:check` in the chain so `check-docs-plan.js` cannot be unhooked. Happy to collapse it to one location if you'd rather.

## What I probed and cleared

- **Package size ceilings** (`MAX_PACKED_SIZE_BYTES`, `MAX_UNPACKED_SIZE_BYTES`, `MAX_PACKAGE_FILE_SIZE_BYTES`) — **no gap.** Widening `64 * 1024` to `128 * 1024` is rejected; respelling the same value as `65536` is correctly accepted. The verdicts do not invert, because the size-violation test asserts the literal byte counts (`65537 exceeds 65536`) computed from the constant. Worth knowing this is load-bearing: `accepts package sizes at the reviewed limits` sizes its fixtures *as* the constant, so it grows with any widening and cannot catch it. The literal counts in the sibling test are the only thing holding these ceilings. Left unchanged.
- `review:mutations` genuinely spawns Jest per mutation in a temp fixture and requires a non-zero exit — a real gating observer, not a source-text assertion.
- `test-makefile-root.sh` already verifies dispatch at the which-arguments level via a command log, and rejects `MAKEFLAGS` `-n/-t/-q/-i`, `MAKEFILES` preload, `MAKEFILE_LIST` override, multi-`-f`, caller `SHELL`, and `PATH`-shadowed tools. `check-docs-plan.js` already rejects `continue-on-error` and `if:` in the workflow.
- `docs:smoke` independently caught a `date-utils` bug during probing (it broke the rendered grid: `expected 70 booking slot buttons, found 0`), which confounded my first exit-status probe. I re-ran it against a pure function invisible to the docs render to isolate the exit-status channel.

## Verification

`make check` exit 0 at the exact pushed head: 403 tests / 16 suites, 5 rejected mutations, Prettier, ESLint, type checks, audit, package-contents, package-runtime, publint, attw. `make build` exit 0 with `git diff --exit-code -- dist` clean. Hosted Node 20/24 still required.

No merge is requested — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
